### PR TITLE
Change access modifier to private protected

### DIFF
--- a/src/Telegram.Bot.Extensions.Filters/CompiledFilters/Filter.cs
+++ b/src/Telegram.Bot.Extensions.Filters/CompiledFilters/Filter.cs
@@ -30,6 +30,9 @@ namespace Telegram.Bot.Extensions.Filters.CompiledFilters
         protected static readonly ParameterExpression Parameter = Expression.Parameter(typeof(T));
         protected static readonly ConstantExpression TrueExpr = Expression.Constant(true, typeof(bool));
 
+        private protected Filter()
+        { }
+
         public static implicit operator Filter<T>(Func<T, bool> predicate)
         {
             return (FuncFilter<T>)predicate;
@@ -43,7 +46,7 @@ namespace Telegram.Bot.Extensions.Filters.CompiledFilters
         /// </summary>
         /// <param name="filter">The filter to evaluate.</param>
         /// <returns>The <see cref="NotFilter{T}"/> negating it.</returns>
-        public static NotFilter<T> operator !(Filter<T> filter)
+        public static Filter<T> operator !(Filter<T> filter)
             => new NotFilter<T>(filter);
 
         /// <summary>
@@ -52,7 +55,7 @@ namespace Telegram.Bot.Extensions.Filters.CompiledFilters
         /// <param name="lhs">The first filter to evaluate.</param>
         /// <param name="rhs">The second filter to evaluate.</param>
         /// <returns>An <see cref="AndFilter{T}"/> joining them.</returns>
-        public static AndFilter<T> operator &(Filter<T> lhs, Filter<T> rhs)
+        public static Filter<T> operator &(Filter<T> lhs, Filter<T> rhs)
             => new AndFilter<T>(lhs, rhs);
 
         /// <summary>
@@ -61,7 +64,7 @@ namespace Telegram.Bot.Extensions.Filters.CompiledFilters
         /// <param name="lhs">The first filter to evaluate.</param>
         /// <param name="rhs">The second filter to evaluate.</param>
         /// <returns>A <see cref="XorFilter{T}"/> joining them.</returns>
-        public static XorFilter<T> operator ^(Filter<T> lhs, Filter<T> rhs)
+        public static Filter<T> operator ^(Filter<T> lhs, Filter<T> rhs)
             => new XorFilter<T>(lhs, rhs);
 
         /// <summary>
@@ -70,7 +73,7 @@ namespace Telegram.Bot.Extensions.Filters.CompiledFilters
         /// <param name="lhs">The first filter to evaluate.</param>
         /// <param name="rhs">The second filter to evaluate.</param>
         /// <returns>An <see cref="OrFilter{T}"/> joining them.</returns>
-        public static OrFilter<T> operator |(Filter<T> lhs, Filter<T> rhs)
+        public static Filter<T> operator |(Filter<T> lhs, Filter<T> rhs)
             => new OrFilter<T>(lhs, rhs);
 
         /// <summary>
@@ -86,13 +89,13 @@ namespace Telegram.Bot.Extensions.Filters.CompiledFilters
         /// </summary>
         /// <param name="filter">The <see cref="Filter{T}"/> to get the <see cref="Expression"/> from.</param>
         /// <returns></returns>
-        protected static Expression GetFilterExpression(Filter<T> filter)
+        private protected static Expression GetFilterExpression(Filter<T> filter)
             => filter.GetFilterExpression();
 
         /// <summary>
         /// Must return the <see cref="Expression"/> that represents the Filter.
         /// </summary>
         /// <returns>The <see cref="Expression"/> representing the Filter.</returns>
-        protected abstract Expression GetFilterExpression();
+        private protected abstract Expression GetFilterExpression();
     }
 }

--- a/src/Telegram.Bot.Extensions.Filters/CompiledFilters/Filters/AndFilter.cs
+++ b/src/Telegram.Bot.Extensions.Filters/CompiledFilters/Filters/AndFilter.cs
@@ -6,7 +6,7 @@ namespace Telegram.Bot.Extensions.Filters.CompiledFilters.Filters
     /// Implements a filter that evaluates to true if both of the other two <see cref="Filter{T}"/>s do.
     /// </summary>
     /// <typeparam name="T">The type of the items.</typeparam>
-    public sealed class AndFilter<T> : Filter<T>
+    internal sealed class AndFilter<T> : Filter<T>
     {
         private readonly Filter<T> _lhs;
         private readonly Filter<T> _rhs;
@@ -23,7 +23,7 @@ namespace Telegram.Bot.Extensions.Filters.CompiledFilters.Filters
             _rhs = rhs;
         }
 
-        protected override Expression GetFilterExpression()
+        private protected override Expression GetFilterExpression()
             => Expression.And(
                 GetFilterExpression(_lhs),
                 GetFilterExpression(_rhs));

--- a/src/Telegram.Bot.Extensions.Filters/CompiledFilters/Filters/ExpressionFilter.cs
+++ b/src/Telegram.Bot.Extensions.Filters/CompiledFilters/Filters/ExpressionFilter.cs
@@ -18,7 +18,7 @@ namespace Telegram.Bot.Extensions.Filters.CompiledFilters.Filters
         public static implicit operator ExpressionFilter<T>(Expression<Func<T, bool>> predicate)
             => new ExpressionFilter<T>(predicate);
 
-        protected override Expression GetFilterExpression()
+        private protected override Expression GetFilterExpression()
             => _expression;
     }
 }

--- a/src/Telegram.Bot.Extensions.Filters/CompiledFilters/Filters/FuncFilter.cs
+++ b/src/Telegram.Bot.Extensions.Filters/CompiledFilters/Filters/FuncFilter.cs
@@ -20,7 +20,7 @@ namespace Telegram.Bot.Extensions.Filters.CompiledFilters.Filters
         public static implicit operator FuncFilter<T>(Func<T, bool> predicate)
             => new FuncFilter<T>(predicate);
 
-        protected override Expression GetFilterExpression()
+        private protected override Expression GetFilterExpression()
             => _callFunc;
     }
 }

--- a/src/Telegram.Bot.Extensions.Filters/CompiledFilters/Filters/NotFilter.cs
+++ b/src/Telegram.Bot.Extensions.Filters/CompiledFilters/Filters/NotFilter.cs
@@ -6,7 +6,7 @@ namespace Telegram.Bot.Extensions.Filters.CompiledFilters.Filters
     /// Implements a filter that evaluates to true if the given <see cref="Filter{T}"/> doesn't and vise versa.
     /// </summary>
     /// <typeparam name="T">The type of the items.</typeparam>
-    public sealed class NotFilter<T> : Filter<T>
+    internal sealed class NotFilter<T> : Filter<T>
     {
         private readonly Filter<T> _filter;
 
@@ -20,7 +20,7 @@ namespace Telegram.Bot.Extensions.Filters.CompiledFilters.Filters
             _filter = filter;
         }
 
-        protected override Expression GetFilterExpression()
+        private protected override Expression GetFilterExpression()
             => Expression.Not(GetFilterExpression(_filter));
     }
 }

--- a/src/Telegram.Bot.Extensions.Filters/CompiledFilters/Filters/OrFilter.cs
+++ b/src/Telegram.Bot.Extensions.Filters/CompiledFilters/Filters/OrFilter.cs
@@ -6,7 +6,7 @@ namespace Telegram.Bot.Extensions.Filters.CompiledFilters.Filters
     /// Implements a filter that evaluates to true if any of the other two <see cref="Filter{T}"/>s do.
     /// </summary>
     /// <typeparam name="T">The type of the items.</typeparam>
-    public sealed class OrFilter<T> : Filter<T>
+    internal sealed class OrFilter<T> : Filter<T>
     {
         private readonly Filter<T> _lhs;
         private readonly Filter<T> _rhs;
@@ -23,7 +23,7 @@ namespace Telegram.Bot.Extensions.Filters.CompiledFilters.Filters
             _rhs = rhs;
         }
 
-        protected override Expression GetFilterExpression()
+        private protected override Expression GetFilterExpression()
             => Expression.Or(
                 GetFilterExpression(_lhs),
                 GetFilterExpression(_rhs));

--- a/src/Telegram.Bot.Extensions.Filters/CompiledFilters/Filters/XorFilter.cs
+++ b/src/Telegram.Bot.Extensions.Filters/CompiledFilters/Filters/XorFilter.cs
@@ -7,7 +7,7 @@ namespace Telegram.Bot.Extensions.Filters.CompiledFilters.Filters
     /// or the other of the other two <see cref="Filter{T}"/>s do.
     /// </summary>
     /// <typeparam name="T">The type of the items.</typeparam>
-    public sealed class XorFilter<T> : Filter<T>
+    internal sealed class XorFilter<T> : Filter<T>
     {
         private readonly Filter<T> _lhs;
         private readonly Filter<T> _rhs;
@@ -24,7 +24,7 @@ namespace Telegram.Bot.Extensions.Filters.CompiledFilters.Filters
             _rhs = rhs;
         }
 
-        protected override Expression GetFilterExpression()
+        private protected override Expression GetFilterExpression()
             => Expression.ExclusiveOr(
                 GetFilterExpression(_lhs),
                 GetFilterExpression(_rhs));

--- a/src/Telegram.Bot.Extensions.Filters/Messages/ForwardFromFilter.cs
+++ b/src/Telegram.Bot.Extensions.Filters/Messages/ForwardFromFilter.cs
@@ -1,7 +1,7 @@
 ﻿namespace Telegram.Bot.Extensions.Filters.Messages
 {
-    public class ForwardFromFilter
+    public sealed class ForwardFromFilter
     {
-        
+
     }
 }

--- a/src/Telegram.Bot.Extensions.Filters/Messages/IsBotFilter.cs
+++ b/src/Telegram.Bot.Extensions.Filters/Messages/IsBotFilter.cs
@@ -9,7 +9,7 @@ namespace Telegram.Bot.Extensions.Filters.Messages
         internal IsBotFilter()
         { }
 
-        protected override Expression GetFilterExpression()
+        private protected override Expression GetFilterExpression()
         {
             var fromProperty = Expression.Property(Parameter, nameof(Message.From));
             var isBotProperty = Expression.Property(fromProperty, nameof(User.IsBot));

--- a/src/Telegram.Bot.Extensions.Filters/Messages/TextFilter.cs
+++ b/src/Telegram.Bot.Extensions.Filters/Messages/TextFilter.cs
@@ -5,7 +5,7 @@ using Telegram.Bot.Types.Enums;
 
 namespace Telegram.Bot.Extensions.Filters.Messages
 {
-    public class TextFilter : Filter<Message>
+    public sealed class TextFilter : Filter<Message>
     {
         private readonly ConstantExpression _text;
 
@@ -17,7 +17,7 @@ namespace Telegram.Bot.Extensions.Filters.Messages
             _text = Expression.Constant(text, typeof(string));
         }
 
-        protected override Expression GetFilterExpression()
+        private protected override Expression GetFilterExpression()
         {
             var textProperty = Expression.Property(Parameter, nameof(Message.Text));
             var typeProperty = Expression.Property(Parameter, nameof(Message.Type));


### PR DESCRIPTION
This ensures that nobody outside defining assembly could extend filter classes. This is due to inability to constrain `GetFilterExpression` return type to expressions that only return boolean.